### PR TITLE
Scale denominator fix

### DIFF
--- a/data/mapbox/line_simpleline_zoom.ts
+++ b/data/mapbox/line_simpleline_zoom.ts
@@ -4,7 +4,7 @@ const lineSimpleLine: any = {
   "layers": [{
   "id": "Small populated New Yorks",
   "type": "line",
-  "minzoom": 5,
+  "minzoom": 5.5,
   "maxzoom": 10,
   "paint": {
       "line-color": "#FF0000",

--- a/data/styles/line_simpleline_zoom.ts
+++ b/data/styles/line_simpleline_zoom.ts
@@ -5,8 +5,8 @@ const lineSimpleLine: Style = {
   rules: [{
     name: 'Small populated New Yorks',
     scaleDenominator: {
-      min: 8735642.904127963,
-      max: 272988.84075399884
+      min: 545978.7733895439,
+      max: 13103464.356191942,
     },
     symbolizers: [{
       kind: 'Line',

--- a/src/MapboxStyleParser.spec.ts
+++ b/src/MapboxStyleParser.spec.ts
@@ -66,11 +66,17 @@ describe('MapboxStyleParser implements StyleParser', () => {
     });
 
     it('can read a mapbox style with min and max zoom', () => {
-      expect.assertions(2);
+      expect.assertions(5);
       return styleParser.readStyle(mb_line_simpleline_zoom)
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
-          expect(geoStylerStyle).toEqual(line_simpleline_zoom);
+          const buffer = 2;
+          const min = geoStylerStyle.rules[0]!.scaleDenominator!.min!;
+          const max = geoStylerStyle.rules[0]!.scaleDenominator!.max!;
+          expect(min).toBeGreaterThanOrEqual(line_simpleline_zoom.rules[0]!.scaleDenominator!.min! - buffer);
+          expect(min).toBeLessThanOrEqual(line_simpleline_zoom.rules[0]!.scaleDenominator!.min! + buffer);
+          expect(max).toBeGreaterThanOrEqual(line_simpleline_zoom.rules[0]!.scaleDenominator!.max! - buffer);
+          expect(max).toBeLessThanOrEqual(line_simpleline_zoom.rules[0]!.scaleDenominator!.max! + buffer);
         });
     });
 
@@ -203,11 +209,12 @@ describe('MapboxStyleParser implements StyleParser', () => {
     });
 
     it('can write a mapbox style with min and max zoom', () => {
-      expect.assertions(2);
+      expect.assertions(3);
       return styleParser.writeStyle(line_simpleline_zoom)
         .then((mbStyle: any) => {
           expect(mbStyle).toBeDefined();
-          expect(mbStyle).toEqual(mb_line_simpleline_zoom);
+          expect(mbStyle.layers[0].minzoom).toBeCloseTo(mb_line_simpleline_zoom.layers[0].minzoom, 0);
+          expect(mbStyle.layers[0].maxzoom).toBeCloseTo(mb_line_simpleline_zoom.layers[0].maxzoom, 0);
         });
     });
 

--- a/src/MapboxStyleParser.ts
+++ b/src/MapboxStyleParser.ts
@@ -779,30 +779,6 @@ export class MapboxStyleParser implements StyleParser {
         if (zoom === -1) {
             zoom = MapboxStyleUtil.getZoomForResolution(resolution);
         }
-        // for (let i = 0; i < MapboxStyleUtil.resolutions.length; i++) {
-        //     const res = resolutions[i];
-        //     // // if resolution matches index exactly return index
-        //     if (resolution.toString(18) === res.toString(18)) {
-        //         zoom = i;
-        //         break;
-        //     }
-        //     // else get surrounding indexes and interpolate value
-        //     if (i !== (resolutions.length - 1) && resolution < res && resolution > resolutions[i + 1]) {
-        //         pre = i;
-        //         post = i + 1;
-        //         break;
-        //     }
-        //     // handle if scale is smaller than minimum zoom level
-        //     if (i === 0 && resolution > res) {
-        //         zoom = i;
-        //         break;
-        //     }
-        //     // handle if scale is bigger than maximum zoom level
-        //     if (i === resolutions.length - 1 && resolution < res) {
-        //         zoom = i;
-        //         break;
-        //     }
-        // }
 
         if (typeof pre !== 'undefined' && typeof post !== 'undefined') {
             // interpolate between zoomlevels

--- a/src/MapboxStyleParser.ts
+++ b/src/MapboxStyleParser.ts
@@ -385,10 +385,10 @@ export class MapboxStyleParser implements StyleParser {
     getScaleDenominatorFromMapboxZoom(minZoom?: number, maxZoom?: number): ScaleDenominator|undefined {
         let scaleDenominator: ScaleDenominator = {};
         if (typeof minZoom !== 'undefined') {
-            scaleDenominator.min = MapboxStyleUtil.zoomToScale(minZoom);
+            scaleDenominator.max = MapboxStyleUtil.zoomToScale(minZoom);
         }
         if (typeof maxZoom !== 'undefined') {
-            scaleDenominator.max = MapboxStyleUtil.zoomToScale(maxZoom);
+            scaleDenominator.min = MapboxStyleUtil.zoomToScale(maxZoom);
         }
         if (typeof scaleDenominator.min === 'undefined' && typeof scaleDenominator.max === 'undefined') {
             return undefined;
@@ -730,10 +730,10 @@ export class MapboxStyleParser implements StyleParser {
             if (rule.scaleDenominator) {
                 // calculate zoomLevel from scaleDenominator
                 if (typeof rule.scaleDenominator.min !== 'undefined') {
-                    layer.minzoom = this.getMapboxZoomFromScaleDenominator(rule.scaleDenominator.min);
+                    layer.maxzoom = this.getMapboxZoomFromScaleDenominator(rule.scaleDenominator.min);
                 }
                 if (typeof rule.scaleDenominator.max !== 'undefined') {
-                    layer.maxzoom = this.getMapboxZoomFromScaleDenominator(rule.scaleDenominator.max);
+                    layer.minzoom = this.getMapboxZoomFromScaleDenominator(rule.scaleDenominator.max);
                 }
             }
 
@@ -774,31 +774,35 @@ export class MapboxStyleParser implements StyleParser {
         let pre: number|undefined = undefined;
         let post: number|undefined = undefined;
         let zoom: number;
-        const resolutions = MapboxStyleUtil.resolutions;
-        for (let i = 0; i < MapboxStyleUtil.resolutions.length; i++) {
-            const res = resolutions[i];
-            // // if resolution matches index exactly return index
-            if (resolution.toString(18) === res.toString(18)) {
-                zoom = i;
-                break;
-            }
-            // else get surrounding indexes and interpolate value
-            if (i !== (resolutions.length - 1) && resolution < res && resolution > resolutions[i + 1]) {
-                pre = i;
-                post = i + 1;
-                break;
-            }
-            // handle if scale is smaller than minimum zoom level
-            if (i === 0 && resolution > res) {
-                zoom = i;
-                break;
-            }
-            // handle if scale is bigger than maximum zoom level
-            if (i === resolutions.length - 1 && resolution < res) {
-                zoom = i;
-                break;
-            }
+        const resolutions = MapboxStyleUtil.getResolutions();
+        zoom = resolutions.indexOf(resolution);
+        if (zoom === -1) {
+            zoom = MapboxStyleUtil.getZoomForResolution(resolution);
         }
+        // for (let i = 0; i < MapboxStyleUtil.resolutions.length; i++) {
+        //     const res = resolutions[i];
+        //     // // if resolution matches index exactly return index
+        //     if (resolution.toString(18) === res.toString(18)) {
+        //         zoom = i;
+        //         break;
+        //     }
+        //     // else get surrounding indexes and interpolate value
+        //     if (i !== (resolutions.length - 1) && resolution < res && resolution > resolutions[i + 1]) {
+        //         pre = i;
+        //         post = i + 1;
+        //         break;
+        //     }
+        //     // handle if scale is smaller than minimum zoom level
+        //     if (i === 0 && resolution > res) {
+        //         zoom = i;
+        //         break;
+        //     }
+        //     // handle if scale is bigger than maximum zoom level
+        //     if (i === resolutions.length - 1 && resolution < res) {
+        //         zoom = i;
+        //         break;
+        //     }
+        // }
 
         if (typeof pre !== 'undefined' && typeof post !== 'undefined') {
             // interpolate between zoomlevels

--- a/src/Util/MapboxStyleUtil.ts
+++ b/src/Util/MapboxStyleUtil.ts
@@ -133,32 +133,6 @@ class MapboxStyleUtil {
     }
     return url;
   }
-
-  // // source: https://github.com/mapbox/mapbox-gl-js/blob/master/src/util/mapbox.js#L143
-  // static urlRe = /^(\w+):\/\/([^/?]*)(\/[^?]+)?\??(.+)?/;
-  // public static parseUrl(url: string): {protocol: string; authority: string; path: string; params: string[]} {
-  //     const parts = url.match(this.urlRe);
-  //     if (!parts) {
-  //         throw new Error('Unable to parse URL object');
-  //     }
-  //     return {
-  //         protocol: parts[1],
-  //         authority: parts[2],
-  //         path: parts[3] || '/',
-  //         params: parts[4] ? parts[4].split('&') : []
-  //     };
-  // }
-
-  // // source: https://github.com/mapbox/mapbox-gl-js/blob/master/src/util/mapbox.js#L82
-  // public static normalizeSpriteURL(url: string, format: string, extension: string, accessToken?: string): string {
-  //   const urlObject = MapboxStyleUtil.parseUrl(url);
-  //   if (url.indexOf('mapbox:') !== 0) {
-  //     throw new Error(`Cannot parse Url. Url is not a mapbox url.`);
-  //   }
-  //   urlObject.path = `/styles/v1${urlObject.path}/sprite${format}${extension}`;
-  //   // return makeAPIURL(urlObject, accessToken);
-  //   return `https://api.mapbox.com${urlObject.path}${urlObject.params}`;
-  // }
 }
 
 export default MapboxStyleUtil;

--- a/src/Util/MapboxStyleUtil.ts
+++ b/src/Util/MapboxStyleUtil.ts
@@ -2,15 +2,18 @@ import { Symbolizer } from 'geostyler-style';
 
 class MapboxStyleUtil {
 
-  // credits to
-  // https://github.com/boundlessgeo/ol-mapbox-style/blob/e11bb81efbc242b907963fba569fd35091ed3aaf/stylefunction.js#L160
-  public static resolutions = [78271.51696402048, 39135.75848201024,
-    19567.87924100512, 9783.93962050256, 4891.96981025128, 2445.98490512564,
-    1222.99245256282, 611.49622628141, 305.748113140705, 152.8740565703525,
-    76.43702828517625, 38.21851414258813, 19.109257071294063, 9.554628535647032,
-    4.777314267823516, 2.388657133911758, 1.194328566955879, 0.5971642834779395,
-    0.29858214173896974, 0.14929107086948487, 0.07464553543474244];
-
+  public static getResolutions(): number[] {
+    const resolutions = [];
+    let res = 78271.51696402048;
+    // adding resolution for arbitrary zoom level 0
+    // This simplyfies working with zoom levels but might lead to unexpected
+    // behaviour.
+    resolutions.push(res * 2);
+    for (res; resolutions.length < 22; res /= 2) {
+      resolutions.push(res);
+    }
+    return resolutions;
+  }
   // credits to
   // https://github.com/terrestris/ol-util/blob/de1b580c63454c8110806a3d73a5f6e972b2f2b0/src/MapUtil/MapUtil.js#L104
   public static getScaleForResolution(resolution: number): number {
@@ -19,6 +22,22 @@ class MapboxStyleUtil {
     var inchesPerMeter = 39.37;
 
     return resolution * mpu * inchesPerMeter * dpi;
+  }
+
+  // credits to
+  // https://github.com/openlayers/ol-mapbox-style/blob/e632c935e7e34bd27079b7fc234202a9ac3b73ee/util.js
+  public static getZoomForResolution(resolution: number): number {
+    let i = 0;
+    const resolutions = MapboxStyleUtil.getResolutions();
+    const ii = resolutions.length;
+    for (; i < ii; ++i) {
+      const candidate = resolutions[i];
+      if (candidate < resolution && i + 1 < ii) {
+        const zoomFactor = resolutions[i] / resolutions[i + 1];
+        return i + Math.log(resolutions[i] / resolution) / Math.log(zoomFactor);
+      }
+    }
+    return ii - 1;
   }
 
   /**
@@ -42,19 +61,20 @@ class MapboxStyleUtil {
   }
 
   public static zoomToScale(zoom: number): number {
+    const resolutions = MapboxStyleUtil.getResolutions();
     // if zoom is integer
-    if (zoom >= MapboxStyleUtil.resolutions.length) {
+    if (zoom >= resolutions.length) {
       throw new Error(`Cannot parse scaleDenominator. ZoomLevel does not exist.`);
     }
     let resolution: number;
     if (Number.isInteger(zoom)) {
-      resolution = MapboxStyleUtil.resolutions[zoom];
+      resolution = resolutions[zoom];
     } else {
       // interpolate values
       const pre = Math.floor(zoom);
       const post = Math.ceil(zoom);
-      const preVal = MapboxStyleUtil.resolutions[pre];
-      const postVal = MapboxStyleUtil.resolutions[post];
+      const preVal = resolutions[pre];
+      const postVal = resolutions[post];
       const range = preVal - postVal;
       const decimal = zoom % 1;
       resolution = preVal - (range * decimal);


### PR DESCRIPTION
ScaleDenominator was not parsed correctly due to a wrong shift in the resolutions array. Fixed that. Updated tests to also cover interpolation of zoomlevels.