### PR TITLE
Parse circlesymbolizer

### DIFF
--- a/data/mapbox/circle_simplecircle.ts
+++ b/data/mapbox/circle_simplecircle.ts
@@ -1,0 +1,20 @@
+const circleSimpleCircle: any = {
+  version: 8,
+  name: 'Simple Circle',
+  layers: [
+    {
+      id: 'Simple Circle',
+      type: 'circle',
+      paint: {
+        'circle-color': '#000000',
+        'circle-radius': 5,
+        'circle-opacity': 1,
+        'circle-stroke-width': 2,
+        'circle-stroke-color': '#FF0000',
+        'circle-stroke-opacity': 0.5
+      }
+    }
+  ]
+};
+
+export default circleSimpleCircle;

--- a/data/styles/circle_simplecircle.ts
+++ b/data/styles/circle_simplecircle.ts
@@ -1,0 +1,20 @@
+import { Style } from 'geostyler-style';
+
+const circleSimpleCircle: Style = {
+  name: 'Simple Circle',
+  rules: [{
+    name: 'Simple Circle',
+    symbolizers: [{
+      kind: 'Mark',
+      wellKnownName: 'Circle',
+      color: '#000000',
+      radius: 5,
+      opacity: 1,
+      strokeWidth: 2,
+      strokeColor: '#FF0000',
+      strokeOpacity: 0.5
+    }]
+  }]
+};
+
+export default circleSimpleCircle;

--- a/src/MapboxStyleParser.spec.ts
+++ b/src/MapboxStyleParser.spec.ts
@@ -23,6 +23,8 @@ import icon_simpleicon from '../data/styles/icon_simpleicon';
 import mb_icon_simpleicon from '../data/mapbox/icon_simpleicon';
 import icon_simpleicon_mapboxapi from '../data/styles/icon_simpleicon_mapboxapi';
 import mb_icon_simpleicon_mapboxapi from '../data/mapbox/icon_simpleicon_mapboxapi';
+import circle_simplecircle from '../data/styles/circle_simplecircle';
+import mb_circle_simplecircle from '../data/mapbox/circle_simplecircle';
 
 it('MapboxStyleParser is defined', () => {
   expect(MapboxStyleParser).toBeDefined();
@@ -140,18 +142,27 @@ describe('MapboxStyleParser implements StyleParser', () => {
     it('can write a mapbox Text style', () => {
       expect.assertions(2);
       return styleParser.writeStyle(point_simpletext)
-        .then((mbStyle: any) => {
-          expect(mbStyle).toBeDefined();
-          expect(mbStyle).toEqual(mb_point_simpletext);
-        });
+      .then((mbStyle: any) => {
+        expect(mbStyle).toBeDefined();
+        expect(mbStyle).toEqual(mb_point_simpletext);
+      });
     });
 
     it('can write a mapbox Text style with a placeholder Text', () => {
       expect.assertions(2);
       return styleParser.writeStyle(point_placeholdertext)
+      .then((mbStyle: any) => {
+        expect(mbStyle).toBeDefined();
+        expect(mbStyle).toEqual(mb_point_placeholdertext);
+      });
+    });
+
+    it('can write a mapbox Circle style', () => {
+      expect.assertions(2);
+      return styleParser.writeStyle(circle_simplecircle)
         .then((mbStyle: any) => {
           expect(mbStyle).toBeDefined();
-          expect(mbStyle).toEqual(mb_point_placeholdertext);
+          expect(mbStyle).toEqual(mb_circle_simplecircle);
         });
     });
 

--- a/src/MapboxStyleParser.spec.ts
+++ b/src/MapboxStyleParser.spec.ts
@@ -92,6 +92,15 @@ describe('MapboxStyleParser implements StyleParser', () => {
         });
     });
 
+    it('can read a mapbox Circle style', () => {
+      expect.assertions(2);
+      return styleParser.readStyle(mb_circle_simplecircle)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(circle_simplecircle);
+        });
+    });
+
     it('can read a mapbox style with multiple layers', () => {
       expect.assertions(2);
       return styleParser.readStyle(mb_multi_simpleline_simplefill)

--- a/src/MapboxStyleParser.ts
+++ b/src/MapboxStyleParser.ts
@@ -59,7 +59,7 @@ export class MapboxStyleParser implements StyleParser {
      * @param {any} layer A Mapbox Style Layer
      * @return {SymbolizerKind} A GeoStylerStyle-SymbolizerKind
      */
-    getSymbolizerKindFromMapboxLayer(type: string): SymbolizerKind|'Symbol' {
+    getSymbolizerKindFromMapboxLayer(type: string): SymbolizerKind|'Symbol'|'Circle' {
         switch (type) {
             case 'fill':
                 return 'Fill';
@@ -67,6 +67,8 @@ export class MapboxStyleParser implements StyleParser {
                 return 'Line';
             case 'symbol':
                 return 'Symbol';
+            case 'circle':
+                return 'Circle';
             default:
                 throw new Error(`Could not parse mapbox style. Unsupported layer type.
                 We support types 'fill', 'line' and 'symbol' only.`);
@@ -136,6 +138,34 @@ export class MapboxStyleParser implements StyleParser {
         url += 'name=' + spriteName;
         url += '&baseurl=' + encodeURIComponent(this._spriteBaseUrl);
         return url;
+    }
+
+    /**
+     * Creates a GeoStylerStyle-MarkSymbolizer with wellKnownName 'circle'
+     * from a Mapbox Style Layer. This one will be handled explicitly
+     * because mapbox has a dedicated layer type for circles. Other shapes are covered
+     * in layer type 'symbol' using fonts.
+     *
+     * @param {any} layer A Mapbox Style Layer
+     * @return {MarkSymbolizer} A GeoStylerStyle-MarkSymbolizer
+     */
+    getCircleSymbolizerFromMapboxLayer(paint: any, layout: any): MarkSymbolizer {
+        return {
+            kind: 'Mark',
+            wellKnownName: 'Circle',
+            visibility: layout['visibility'],
+            radius: paint['circle-radius'],
+            color: paint['circle-color'],
+            blur: paint['circle-blur'],
+            opacity: paint['circle-opacity'],
+            translate: paint['circle-translate'],
+            translateAnchor: paint['circle-translate-anchor'],
+            pitchScale: paint['circle-pitch-scale'],
+            pitchAlignment: paint['circle-pitch-alignment'],
+            strokeWidth: paint['circle-stroke-width'],
+            strokeColor: paint['circle-stroke-color'],
+            strokeOpacity: paint['circle-stroke-opacity']
+        };
     }
 
     /**
@@ -284,7 +314,7 @@ export class MapboxStyleParser implements StyleParser {
      */
     getSymbolizerFromMapboxLayer(paint: any, layout: any, type: string): Symbolizer|SymbolType {
         let symbolizer: Symbolizer = {} as Symbolizer;
-        const kind: SymbolizerKind|'Symbol' = this.getSymbolizerKindFromMapboxLayer(type);
+        const kind: SymbolizerKind|'Symbol'|'Circle' = this.getSymbolizerKindFromMapboxLayer(type);
 
         switch (kind) {
             case 'Fill':
@@ -295,6 +325,8 @@ export class MapboxStyleParser implements StyleParser {
                 break;
             case 'Symbol':
                 return this.getIconTextSymbolizersFromMapboxLayer(paint, layout);
+            case 'Circle':
+                return this.getCircleSymbolizerFromMapboxLayer(paint, layout);
             case 'Mark':
                 symbolizer = this.getMarkSymbolizerFromMapboxLayer(paint, layout);
                 break;

--- a/src/MapboxStyleParser.ts
+++ b/src/MapboxStyleParser.ts
@@ -857,6 +857,15 @@ export class MapboxStyleParser implements StyleParser {
                 layout = this.getLayoutFromTextSymbolizer(symbolizerClone as TextSymbolizer);
                 break;
             case 'Mark':
+                if (symbolizer.wellKnownName === 'Circle') {
+                    layerType = 'circle';
+                    paint = this.getPaintFromCircleSymbolizer(symbolizerClone as MarkSymbolizer);
+                    layout = this.getLayoutFromCircleSymbolizer(symbolizerClone as MarkSymbolizer);
+                    break;
+                } else {
+                    throw new Error(`Cannot get Style. Unsupported MarkSymbolizer`);
+                }
+
             // TODO check if mapbox can generate regular shapes
             default:
                 throw new Error(`Cannot get Style. Unsupported kind.`);
@@ -885,7 +894,7 @@ export class MapboxStyleParser implements StyleParser {
             translateAnchor
         } = symbolizer;
 
-        let paint: any = {
+        const paint: any = {
             'fill-antialias': antialias,
             'fill-opacity': opacity,
             'fill-color': color,
@@ -908,7 +917,7 @@ export class MapboxStyleParser implements StyleParser {
             visibility
         } = symbolizer;
 
-        let layout: any = {
+        const layout: any = {
             'visibility': this.getVisibility(visibility)
         };
         return layout;
@@ -999,7 +1008,7 @@ export class MapboxStyleParser implements StyleParser {
             translateAnchor
         } = symbolizer;
 
-        let paint: any = {
+        const paint: any = {
             'line-opacity': opacity,
             'line-color': color,
             'line-translate': translate,
@@ -1057,7 +1066,7 @@ export class MapboxStyleParser implements StyleParser {
             translateAnchor,
         } = symbolizer;
 
-        let paint: any = {
+        const paint: any = {
             'icon-opacity': opacity,
             'icon-color': color,
             'icon-halo-color': haloColor,
@@ -1135,7 +1144,7 @@ export class MapboxStyleParser implements StyleParser {
             translateAnchor
         } = symbolizer;
 
-        let paint: any = {
+        const paint: any = {
             'text-opacity': opacity,
             'text-color': color,
             'text-halo-color': haloColor,
@@ -1180,7 +1189,7 @@ export class MapboxStyleParser implements StyleParser {
             visibility
         } = symbolizer;
 
-        let paint: any = {
+        const paint: any = {
             'symbol-spacing': spacing,
             'symbol-avoid-edges': avoidEdges,
             'text-pitch-alignment': pitchAlignment,
@@ -1253,6 +1262,65 @@ export class MapboxStyleParser implements StyleParser {
         }
     }
 
+    /**
+     * Creates a Mapbox Layer Paint object from a GeoStylerStyle-MarkSymbolizer
+     * that uses the wellKnownName 'circle'. This one will be handled explicitly
+     * because mapbox has a dedicated layer type for circles. Other shapes are covered
+     * in layer type 'symbol' using fonts.
+     *
+     * @param {MarkSymbolizer} symbolizer A GeoStylerStyle MarkSymbolizer with wkn 'circle'
+     * @return {any} A Mapbox Layer Paint object
+     */
+    getPaintFromCircleSymbolizer(symbolizer: MarkSymbolizer): any {
+        const {
+            radius,
+            color,
+            blur,
+            opacity,
+            translate,
+            translateAnchor,
+            pitchScale,
+            pitchAlignment,
+            strokeWidth,
+            strokeColor,
+            strokeOpacity
+        } = symbolizer;
+
+        const paint = {
+            'circle-radius': radius,
+            'circle-color': color,
+            'circle-blur': blur,
+            'circle-opacity': opacity,
+            'circle-translate': translate,
+            'circle-translate-anchor': translateAnchor,
+            'circle-pitch-scale': pitchScale,
+            'circle-pitch-alignment': pitchAlignment,
+            'circle-stroke-width': strokeWidth,
+            'circle-stroke-color': strokeColor,
+            'circle-stroke-opacity': strokeOpacity
+        };
+        return paint;
+    }
+
+    /**
+     * Creates a Mapbox Layer Layout object from a GeoStylerStyle-MarkSymbolizer
+     * that uses the wellKnownName 'circle'. This one will be handled explicitly
+     * because mapbox has a dedicated layer type for circles. Other shapes are covered
+     * in layer type 'symbol' using fonts.
+     *
+     * @param {MarkSymbolizer} symbolizer A GeoStylerStyle MarkSymbolizer with wkn 'circle'
+     * @return {any} A Mapbox Layer Layout object
+     */
+    getLayoutFromCircleSymbolizer(symbolizer: MarkSymbolizer): any {
+        const {
+            visibility
+        } = symbolizer;
+
+        const layout = {
+            'visibility': visibility
+        };
+        return layout;
+    }
 }
 
 export default MapboxStyleParser;


### PR DESCRIPTION
Mapbox specifies a dedicated layer type for circles. Other shapes are covered under the layer type `symbol` using fonts. Parser checks if layer type/wellknownname is `circle` and reads/writes accordingly.