### PR TITLE
Fill pattern

### DIFF
--- a/data/mapbox/fill_patternfill.ts
+++ b/data/mapbox/fill_patternfill.ts
@@ -1,13 +1,15 @@
 const fillSimpleFill: any = {
   version: 8,
-  name: 'Simple Fill',
+  name: 'Pattern Fill',
+  sprite: 'https://testurl.com',
   layers: [
     {
-      id: 'Simple Fill',
+      id: 'Pattern Fill',
       type: 'fill',
       paint: {
         'fill-color': '#000000',
-        'fill-opacity': 1
+        'fill-opacity': 1,
+        'fill-pattern': 'poi'
       }
     }
   ]

--- a/data/mapbox/line_patternline.ts
+++ b/data/mapbox/line_patternline.ts
@@ -1,0 +1,23 @@
+const linePatternLine: any = {
+  "version": 8,
+  "name": "Pattern Line",
+  "sprite": 'https://testurl.com',
+  "layers": [
+    {
+      "id": "Pattern Line",
+      "type": "line",
+      "paint": {
+        "line-color": "#000000",
+        "line-width": 3,
+        "line-dasharray": [13, 37],
+        "line-pattern": "poi"
+      },
+      "layout": {
+        "line-cap": "round",
+        "line-join": "miter"
+      }
+    }
+  ]
+};
+
+export default linePatternLine;

--- a/data/styles/fill_patternfill.ts
+++ b/data/styles/fill_patternfill.ts
@@ -1,0 +1,19 @@
+import { Style } from 'geostyler-style';
+
+const fillPatternFill: Style = {
+  name: 'Pattern Fill',
+  rules: [{
+    name: 'Pattern Fill',
+    symbolizers: [{
+      kind: 'Fill',
+      color: '#000000',
+      opacity: 1,
+      graphicFill: {
+        kind: 'Icon',
+        image: "/sprites/?name=poi&baseurl=" + encodeURIComponent("https://testurl.com")
+      }
+    }]
+  }]
+};
+
+export default fillPatternFill;

--- a/data/styles/line_patternline.ts
+++ b/data/styles/line_patternline.ts
@@ -1,0 +1,22 @@
+import { Style } from "geostyler-style";
+
+const linePatternLine: Style = {
+  "name": "Pattern Line",
+  "rules": [{
+    "name": "Pattern Line",
+    "symbolizers": [{
+      "kind": "Line",
+      "color": "#000000",
+      "width": 3,
+      "dasharray": [13, 37],
+      "cap": "round",
+      "join": "miter",
+      "graphicFill": {
+        kind: 'Icon',
+        image: "/sprites/?name=poi&baseurl=" + encodeURIComponent("https://testurl.com")
+      }
+    }]
+  }]
+};
+
+export default linePatternLine;

--- a/src/MapboxStyleParser.spec.ts
+++ b/src/MapboxStyleParser.spec.ts
@@ -25,6 +25,10 @@ import icon_simpleicon_mapboxapi from '../data/styles/icon_simpleicon_mapboxapi'
 import mb_icon_simpleicon_mapboxapi from '../data/mapbox/icon_simpleicon_mapboxapi';
 import circle_simplecircle from '../data/styles/circle_simplecircle';
 import mb_circle_simplecircle from '../data/mapbox/circle_simplecircle';
+import fill_patternfill from '../data/styles/fill_patternfill';
+import mb_fill_patternfill from '../data/mapbox/fill_patternfill';
+import line_patternline from '../data/styles/line_patternline';
+import mb_line_patternline from '../data/mapbox/line_patternline';
 
 it('MapboxStyleParser is defined', () => {
   expect(MapboxStyleParser).toBeDefined();
@@ -44,6 +48,33 @@ describe('MapboxStyleParser implements StyleParser', () => {
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
           expect(geoStylerStyle).toEqual(line_simpleline);
+        });
+    });
+
+    it('can read a mapbox Line style with fill pattern', () => {
+      expect.assertions(2);
+      return styleParser.readStyle(mb_line_patternline)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(line_patternline);
+        });
+    });
+
+    it('can read a mapbox Fill style', () => {
+      expect.assertions(2);
+      return styleParser.readStyle(mb_fill_simplefill)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(fill_simplefill);
+        });
+    });
+
+    it('can read a mapbox Fill style with fill pattern', () => {
+      expect.assertions(2);
+      return styleParser.readStyle(mb_fill_patternfill)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(fill_patternfill);
         });
     });
 
@@ -139,12 +170,30 @@ describe('MapboxStyleParser implements StyleParser', () => {
         });
     });
 
+    it('can write a mapbox Line style with fill pattern', () => {
+      expect.assertions(2);
+      return styleParser.writeStyle(line_patternline)
+        .then((mbStyle: any) => {
+          expect(mbStyle).toBeDefined();
+          expect(mbStyle).toEqual(mb_line_patternline);
+        });
+    });
+
     it('can write a mapbox Fill style', () => {
       expect.assertions(2);
       return styleParser.writeStyle(fill_simplefill)
         .then((mbStyle: any) => {
           expect(mbStyle).toBeDefined();
           expect(mbStyle).toEqual(mb_fill_simplefill);
+        });
+    });
+
+    it('can write a mapbox Fill style with fill pattern', () => {
+      expect.assertions(2);
+      return styleParser.writeStyle(fill_patternfill)
+        .then((mbStyle: any) => {
+          expect(mbStyle).toBeDefined();
+          expect(mbStyle).toEqual(mb_fill_patternfill);
         });
     });
 

--- a/src/MapboxStyleParser.ts
+++ b/src/MapboxStyleParser.ts
@@ -43,11 +43,11 @@ export class MapboxStyleParser implements StyleParser {
         Symbolizer: {
             FillSymbolizer: {
                 outlineWidth: 'unsupported',
-                outlineDasharray: 'unsupported',
-                graphicFill: 'unsupported',
+                outlineDasharray: 'unsupported'
             },
             LineSymbolizer: {
-                dashOffset: 'unsupported'
+                dashOffset: 'unsupported',
+                graphicStroke: 'unsupported'
             },
             MarkSymbolizer: 'unsupported'
         }
@@ -261,8 +261,18 @@ export class MapboxStyleParser implements StyleParser {
             outlineColor: paint['fill-outline-color'],
             translate: paint['fill-translate'],
             translateAnchor: paint['fill-translate-anchor'],
-            graphicFill: paint['fill-pattern']
+            graphicFill: this.getPatternOrGradientFromMapboxLayer(paint['fill-pattern'])
         };
+    }
+
+    getPatternOrGradientFromMapboxLayer(icon: any): IconSymbolizer|undefined {
+        if (Array.isArray(icon)) {
+            throw new Error(`Cannot parse pattern or gradient. No Mapbox expressions allowed`);
+        }
+        if (!icon) {
+            return;
+        }
+        return this.getIconSymbolizerFromMapboxLayer({}, {'icon-image': icon});
     }
 
     /**
@@ -288,8 +298,8 @@ export class MapboxStyleParser implements StyleParser {
             perpendicularOffset: paint['line-offset'],
             blur: paint['line-blur'],
             dasharray: paint['line-dasharray'],
-            graphicFill: paint['line-pattern'],
-            graphicStroke: paint['line-gradient']
+            gradient: paint['line-gradient'],
+            graphicFill: this.getPatternOrGradientFromMapboxLayer(paint['line-pattern'])
         };
     }
 
@@ -1035,7 +1045,7 @@ export class MapboxStyleParser implements StyleParser {
             dasharray,
             graphicFill,
             gapWidth,
-            graphicStroke,
+            gradient,
             translate,
             translateAnchor
         } = symbolizer;
@@ -1051,7 +1061,7 @@ export class MapboxStyleParser implements StyleParser {
             'line-blur': blur,
             'line-dasharray': dasharray,
             'line-pattern': this.getPatternOrGradientFromPointSymbolizer(graphicFill),
-            'line-gradient': this.getPatternOrGradientFromPointSymbolizer(graphicStroke)
+            'line-gradient': gradient
         };
         return paint;
     }

--- a/src/Util/MapboxStyleUtil.ts
+++ b/src/Util/MapboxStyleUtil.ts
@@ -80,7 +80,7 @@ class MapboxStyleUtil {
    *
    * @param symbolizer A GeoStylerStyle Symbolizer
    */
-  public static symbolizerAllUndefined (symbolizer: Symbolizer): boolean {
+  public static symbolizerAllUndefined(symbolizer: Symbolizer): boolean {
     return !Object.keys(symbolizer)
       .filter((val: string) => val !== 'kind')
       .some((val: string) => typeof symbolizer[val] !== 'undefined');
@@ -91,7 +91,7 @@ class MapboxStyleUtil {
    *
    * @param url URL
    */
-  public static getUrlForMbPlaceholder (url: string): string {
+  public static getUrlForMbPlaceholder(url: string): string {
     const mbPlaceholder = 'mapbox://';
     const mbUrl = 'https://api.mapbox.com/';
     if (url && url.startsWith(mbPlaceholder)) {


### PR DESCRIPTION
Parses fill patterns for LineSymbolizers and FillSymbolizers. Mapbox Expressions are currently not allowed in related mapbox properties (`line-pattern`, `fill-pattern`).