### PR TITLE
parse mapbox label placeholders

### DIFF
--- a/data/mapbox/point_placeholderText_simple.ts
+++ b/data/mapbox/point_placeholderText_simple.ts
@@ -1,0 +1,19 @@
+const pointPlaceholderText: any = {
+  version: 8,
+  name: 'Placeholder Text',
+  layers: [
+    {
+      id: 'Placeholder Text',
+      type: 'symbol',
+      layout: {
+        'text-field': '{River}'
+      },
+      paint: {
+        'text-color': '#000000',
+        'text-opacity': 1
+      }
+    }
+  ]
+};
+
+export default pointPlaceholderText;

--- a/data/styles/point_placeholderText_simple.ts
+++ b/data/styles/point_placeholderText_simple.ts
@@ -1,0 +1,16 @@
+import { Style } from 'geostyler-style';
+
+const pointPlaceholderText: Style = {
+  name: 'Placeholder Text',
+  rules: [{
+    name: 'Placeholder Text',
+    symbolizers: [{
+      kind: 'Text',
+      label: '{{River}}',
+      color: '#000000',
+      opacity: 1
+    }]
+  }]
+};
+
+export default pointPlaceholderText;

--- a/src/MapboxStyleParser.spec.ts
+++ b/src/MapboxStyleParser.spec.ts
@@ -29,6 +29,8 @@ import fill_patternfill from '../data/styles/fill_patternfill';
 import mb_fill_patternfill from '../data/mapbox/fill_patternfill';
 import line_patternline from '../data/styles/line_patternline';
 import mb_line_patternline from '../data/mapbox/line_patternline';
+import point_placeholdertext_simple from '../data/styles/point_placeholderText_simple';
+import mb_point_placeholdertext_simple from '../data/mapbox/point_placeholderText_simple';
 
 it('MapboxStyleParser is defined', () => {
   expect(MapboxStyleParser).toBeDefined();
@@ -129,6 +131,15 @@ describe('MapboxStyleParser implements StyleParser', () => {
         });
     });
 
+    it('can read a mapbox Text style with formatted Text', () => {
+      expect.assertions(2);
+      return styleParser.readStyle(mb_point_placeholdertext_simple)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(point_placeholdertext_simple);
+        });
+    });
+
     it('can read a mapbox Circle style', () => {
       expect.assertions(2);
       return styleParser.readStyle(mb_circle_simplecircle)
@@ -214,10 +225,10 @@ describe('MapboxStyleParser implements StyleParser', () => {
 
     it('can write a mapbox Text style with a placeholder Text', () => {
       expect.assertions(2);
-      return styleParser.writeStyle(point_placeholdertext)
+      return styleParser.writeStyle(point_placeholdertext_simple)
       .then((mbStyle: any) => {
         expect(mbStyle).toBeDefined();
-        expect(mbStyle).toEqual(mb_point_placeholdertext);
+        expect(mbStyle).toEqual(mb_point_placeholdertext_simple);
       });
     });
 

--- a/src/MapboxStyleParser.ts
+++ b/src/MapboxStyleParser.ts
@@ -71,7 +71,7 @@ export class MapboxStyleParser implements StyleParser {
                 return 'Circle';
             default:
                 throw new Error(`Could not parse mapbox style. Unsupported layer type.
-                We support types 'fill', 'line' and 'symbol' only.`);
+                We support types 'fill', 'line', 'circle' and 'symbol' only.`);
         }
     }
 
@@ -86,7 +86,7 @@ export class MapboxStyleParser implements StyleParser {
             return;
         }
         if (typeof label === 'string') {
-            return label;
+            return MapboxStyleUtil.resolveMbTextPlaceholder(label);
         }
         if (label[0] !== 'format') {
             throw new Error(`Cannot parse mapbox style. Unsupported text format.`);
@@ -1254,34 +1254,9 @@ export class MapboxStyleParser implements StyleParser {
         // RegExp to match all occurences encapsuled between two curly braces
         // including the curly braces
         let regExp: RegExp = new RegExp(prefix + '.*?' + suffix, 'g');
-        let regExpRes = template.match(regExp);
-
-        // if no template was used, return as fix string
-        if (!regExpRes) {
-            return template;
-            // if templates are being used
-        } else {
-            // split the original string before the occurence of a placeholder
-            const regLookAhead = new RegExp('(?=' + prefix + '.*?' + suffix + ')', 'g');
-            const literalsWEmptyStrings = template.split(regLookAhead);
-            // mapbox format
-            const format: any[] = ['format'];
-            literalsWEmptyStrings.forEach((lit: string) => {
-                if (lit.startsWith('{{')) {
-                    const delimiter = lit.indexOf('}}');
-                    const placeholder = lit.substring(2, delimiter);
-                    const text = lit.substring(delimiter + 2);
-                    format.push(['get', placeholder], {});
-                    if (text.length > 0) {
-                        format.push(text, {});
-                    }
-                } else {
-                    format.push(lit, {});
-                }
-            });
-
-            return format;
-        }
+        return template.replace(regExp, (match: string) => {
+            return match.slice(1, -1);
+        });
     }
 
     /**

--- a/src/Util/MapboxStyleUtil.ts
+++ b/src/Util/MapboxStyleUtil.ts
@@ -125,13 +125,32 @@ class MapboxStyleUtil {
    *
    * @param url URL
    */
-  public static getMbPlaceholderForUrl (url: string): string {
+  public static getMbPlaceholderForUrl(url: string): string {
     const mbPlaceholder = 'mapbox://';
     const mbUrl = 'https://api.mapbox.com/';
     if (url && url.startsWith(mbUrl)) {
       return url.replace(mbUrl, mbPlaceholder);
     }
     return url;
+  }
+
+  /**
+   * Resolves a mapbox text-field placeholder string to a geostyler-style
+   * placeholder string. I.e. replaces {varname} with {{varname}}.
+   *
+   * @param template Template string that should be resolved
+   */
+  public static resolveMbTextPlaceholder(template: string): string {
+    // prefix indicating that a template is being used
+    const prefix: string = '\\{';
+    // suffix indicating that a template is being used
+    const suffix: string = '\\}';
+
+    let regExp: RegExp = new RegExp(prefix + '.*?' + suffix, 'g');
+    const gsLabel = template.replace(regExp, (match: string) => {
+      return `{${match}}`;
+    });
+    return gsLabel;
   }
 }
 


### PR DESCRIPTION
Mapbox allows label placeholders/variables in following format `"{varname}"`. This will be parsed now. Added tests. Removed parsing of formatted text (temporarily?) for writeStyle(). From geostyler-style we cannot make proper assumptions for creating mapbox `format` expression. 