### PR TITLE
fix variables in filters

### DIFF
--- a/data/mapbox/line_simpleline_basefilter.ts
+++ b/data/mapbox/line_simpleline_basefilter.ts
@@ -5,15 +5,15 @@ const lineSimpleLine: any = {
     id: "Small populated New Yorks",
     type: "line",
     filter: ["all",
-      ["==", ["get", "NAME"], "New York"],
-      ["==", ["get", "TEST_BOOL"], "true"],
-      ["==", ["get", "TEST"], null],
-      ["*=", ["get", "TEST2"], "*York*"],
-      ["*=", ["get", "TEST1"], "*New*"],
-      ["!", [">", ["get", "POPULATION"], "100000"]],
+      ["==", "NAME", "New York"],
+      ["==", "TEST_BOOL", "true"],
+      ["==", "TEST", null],
+      ["*=", "TEST2", "*York*"],
+      ["*=", "TEST1", "*New*"],
+      ["!", [">", "POPULATION", "100000"]],
       ["any",
-        ["==", ["get", "TEST2"], "1"],
-        ["==", ["get", "TEST2"], "2"]
+        ["==", "TEST2", "1"],
+        ["==", "TEST2", "2"]
       ]
     ],
     paint: {

--- a/data/mapbox/line_simpleline_filter.ts
+++ b/data/mapbox/line_simpleline_filter.ts
@@ -5,23 +5,23 @@ const lineSimpleLine: any = {
     id: 'Small populated New Yorks',
     type: 'line',
     filter: ['all',
-      ['==', ['get', 'NAME'], 'New York'],
-      ['==', ['get', 'TEST_BOOL'], 'true'],
-      ['==', ['get', 'TEST'], null],
-      ['*=', ['get', 'TEST2'], '*York*'],
-      ['*=', ['get', 'TEST1'], '*New*'],
-      ['!', ['>', ['get', 'POPULATION'], '100000']],
+      ['==', 'NAME', 'New York'],
+      ['==', 'TEST_BOOL', 'true'],
+      ['==', 'TEST', null],
+      ['*=', 'TEST2', '*York*'],
+      ['*=', 'TEST1', '*New*'],
+      ['!', ['>', 'POPULATION', '100000']],
       ['any',
-        ['==', ['get', 'TEST2'], '1'],
-        ['==', ['get', 'TEST2'], '2']
+        ['==', 'TEST2', '1'],
+        ['==', 'TEST2', '2']
       ]
     ],
     paint: {
       'line-color': '#FF0000',
       'line-width': ['case',
-        ['==', ['get', 'DENSITY'], 20],
+        ['==', 'DENSITY', 20],
         3,
-        ['!=', ['get', 'DENSITY'], 20],
+        ['!=', 'DENSITY', 20],
         5
       ]
     }

--- a/src/MapboxStyleParser.ts
+++ b/src/MapboxStyleParser.ts
@@ -379,8 +379,6 @@ export class MapboxStyleParser implements StyleParser {
             restFilter.forEach((f: Filter) => {
                 this.getFilterFromMapboxFilter(f);
             });
-        } else {
-            filter[1] = filter[1][1];
         }
         return filter;
     }
@@ -839,8 +837,6 @@ export class MapboxStyleParser implements StyleParser {
             restFilter.forEach((f: Filter) => {
                 this.getMapboxFilterFromFilter(f);
             });
-        } else {
-            filter[1] = ['get', filter[1]];
         }
         return filter;
     }


### PR DESCRIPTION
Mapbox filters do not require the `get` expression when using variables. Instead, simple strings also work. Parser assumed `get` will always be used. This lead to errors when parsing simple strings in filter-expressions. Now strings are usable. Updated tests accordingly.