### PR TITLE
Add flag to ignore conversion errors

### DIFF
--- a/data/styles/line_simpleline_zoom.ts
+++ b/data/styles/line_simpleline_zoom.ts
@@ -5,8 +5,8 @@ const lineSimpleLine: Style = {
   rules: [{
     name: 'Small populated New Yorks',
     scaleDenominator: {
-      min: 545978.7733895439,
-      max: 13103464.356191942,
+      min: 545978.7909368654,
+      max: 12354089.774575673,
     },
     symbolizers: [{
       kind: 'Line',

--- a/src/MapboxStyleParser.spec.ts
+++ b/src/MapboxStyleParser.spec.ts
@@ -103,13 +103,12 @@ describe('MapboxStyleParser implements StyleParser', () => {
       return styleParser.readStyle(mb_line_simpleline_zoom)
         .then((geoStylerStyle: Style) => {
           expect(geoStylerStyle).toBeDefined();
-          const buffer = 2;
           const min = geoStylerStyle.rules[0]!.scaleDenominator!.min!;
           const max = geoStylerStyle.rules[0]!.scaleDenominator!.max!;
-          expect(min).toBeGreaterThanOrEqual(line_simpleline_zoom.rules[0]!.scaleDenominator!.min! - buffer);
-          expect(min).toBeLessThanOrEqual(line_simpleline_zoom.rules[0]!.scaleDenominator!.min! + buffer);
-          expect(max).toBeGreaterThanOrEqual(line_simpleline_zoom.rules[0]!.scaleDenominator!.max! - buffer);
-          expect(max).toBeLessThanOrEqual(line_simpleline_zoom.rules[0]!.scaleDenominator!.max! + buffer);
+          expect(min).toBeGreaterThanOrEqual(line_simpleline_zoom.rules[0]!.scaleDenominator!.min!);
+          expect(min).toBeLessThanOrEqual(line_simpleline_zoom.rules[0]!.scaleDenominator!.min!);
+          expect(max).toBeGreaterThanOrEqual(line_simpleline_zoom.rules[0]!.scaleDenominator!.max!);
+          expect(max).toBeLessThanOrEqual(line_simpleline_zoom.rules[0]!.scaleDenominator!.max!);
         });
     });
 

--- a/src/MapboxStyleParser.spec.ts
+++ b/src/MapboxStyleParser.spec.ts
@@ -112,6 +112,23 @@ describe('MapboxStyleParser implements StyleParser', () => {
         });
     });
 
+    it('can write and read a mapbox style with min and max zoom', () => {
+      expect.assertions(5);
+      return styleParser.writeStyle(line_simpleline_zoom)
+        .then(mbStyle => {
+          styleParser.readStyle(mbStyle)
+            .then((geoStylerStyle: Style) => {
+              expect(geoStylerStyle).toBeDefined();
+              const min = geoStylerStyle.rules[0]!.scaleDenominator!.min!;
+              const max = geoStylerStyle.rules[0]!.scaleDenominator!.max!;
+              expect(min).toBeGreaterThanOrEqual(line_simpleline_zoom.rules[0]!.scaleDenominator!.min!);
+              expect(min).toBeLessThanOrEqual(line_simpleline_zoom.rules[0]!.scaleDenominator!.min!);
+              expect(max).toBeGreaterThanOrEqual(line_simpleline_zoom.rules[0]!.scaleDenominator!.max!);
+              expect(max).toBeLessThanOrEqual(line_simpleline_zoom.rules[0]!.scaleDenominator!.max!);
+            });
+          });
+    });
+
     it('can read a mapbox Text style', () => {
       expect.assertions(2);
       return styleParser.readStyle(mb_point_simpletext)

--- a/src/MapboxStyleParser.spec.ts
+++ b/src/MapboxStyleParser.spec.ts
@@ -183,7 +183,7 @@ describe('MapboxStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(line_simpleline)
         .then((mbStyle: any) => {
           expect(mbStyle).toBeDefined();
-          expect(mbStyle).toEqual(mb_line_simpleline);
+          expect(JSON.parse(mbStyle)).toEqual(mb_line_simpleline);
         });
     });
 
@@ -192,7 +192,7 @@ describe('MapboxStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(line_patternline)
         .then((mbStyle: any) => {
           expect(mbStyle).toBeDefined();
-          expect(mbStyle).toEqual(mb_line_patternline);
+          expect(JSON.parse(mbStyle)).toEqual(mb_line_patternline);
         });
     });
 
@@ -201,7 +201,7 @@ describe('MapboxStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(fill_simplefill)
         .then((mbStyle: any) => {
           expect(mbStyle).toBeDefined();
-          expect(mbStyle).toEqual(mb_fill_simplefill);
+          expect(JSON.parse(mbStyle)).toEqual(mb_fill_simplefill);
         });
     });
 
@@ -210,7 +210,7 @@ describe('MapboxStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(fill_patternfill)
         .then((mbStyle: any) => {
           expect(mbStyle).toBeDefined();
-          expect(mbStyle).toEqual(mb_fill_patternfill);
+          expect(JSON.parse(mbStyle)).toEqual(mb_fill_patternfill);
         });
     });
 
@@ -219,7 +219,7 @@ describe('MapboxStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_simpletext)
       .then((mbStyle: any) => {
         expect(mbStyle).toBeDefined();
-        expect(mbStyle).toEqual(mb_point_simpletext);
+        expect(JSON.parse(mbStyle)).toEqual(mb_point_simpletext);
       });
     });
 
@@ -228,7 +228,7 @@ describe('MapboxStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(point_placeholdertext_simple)
       .then((mbStyle: any) => {
         expect(mbStyle).toBeDefined();
-        expect(mbStyle).toEqual(mb_point_placeholdertext_simple);
+        expect(JSON.parse(mbStyle)).toEqual(mb_point_placeholdertext_simple);
       });
     });
 
@@ -237,7 +237,7 @@ describe('MapboxStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(circle_simplecircle)
         .then((mbStyle: any) => {
           expect(mbStyle).toBeDefined();
-          expect(mbStyle).toEqual(mb_circle_simplecircle);
+          expect(JSON.parse(mbStyle)).toEqual(mb_circle_simplecircle);
         });
     });
 
@@ -246,7 +246,7 @@ describe('MapboxStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(multi_simpleline_simplefill)
         .then((mbStyle: any) => {
           expect(mbStyle).toBeDefined();
-          expect(mbStyle).toEqual(mb_multi_simpleline_simplefill);
+          expect(JSON.parse(mbStyle)).toEqual(mb_multi_simpleline_simplefill);
         });
     });
 
@@ -255,7 +255,7 @@ describe('MapboxStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(multi_rule_line_fill)
         .then((mbStyle: any) => {
           expect(mbStyle).toBeDefined();
-          expect(mbStyle).toEqual(mb_multi_rule_line_fill);
+          expect(JSON.parse(mbStyle)).toEqual(mb_multi_rule_line_fill);
         });
     });
 
@@ -264,7 +264,7 @@ describe('MapboxStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(line_simpleline_basefilter)
         .then((mbStyle: any) => {
           expect(mbStyle).toBeDefined();
-          expect(mbStyle).toEqual(mb_line_simpleline_basefilter);
+          expect(JSON.parse(mbStyle)).toEqual(mb_line_simpleline_basefilter);
         });
     });
 
@@ -273,6 +273,7 @@ describe('MapboxStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(line_simpleline_zoom)
         .then((mbStyle: any) => {
           expect(mbStyle).toBeDefined();
+          mbStyle = JSON.parse(mbStyle);
           expect(mbStyle.layers[0].minzoom).toBeCloseTo(mb_line_simpleline_zoom.layers[0].minzoom, 0);
           expect(mbStyle.layers[0].maxzoom).toBeCloseTo(mb_line_simpleline_zoom.layers[0].maxzoom, 0);
         });
@@ -283,7 +284,7 @@ describe('MapboxStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(icon_simpleicon)
         .then((mbStyle: any) => {
           expect(mbStyle).toBeDefined();
-          expect(mbStyle).toEqual(mb_icon_simpleicon);
+          expect(JSON.parse(mbStyle)).toEqual(mb_icon_simpleicon);
         });
     });
 
@@ -292,7 +293,7 @@ describe('MapboxStyleParser implements StyleParser', () => {
       return styleParser.writeStyle(icon_simpleicon_mapboxapi)
         .then((mbStyle: any) => {
           expect(mbStyle).toBeDefined();
-          expect(mbStyle).toEqual(mb_icon_simpleicon_mapboxapi);
+          expect(JSON.parse(mbStyle)).toEqual(mb_icon_simpleicon_mapboxapi);
         });
     });
   });

--- a/src/MapboxStyleParser.ts
+++ b/src/MapboxStyleParser.ts
@@ -43,7 +43,7 @@ export class MapboxStyleParser implements StyleParser {
 
     public ignoreConversionErrors: boolean = false;
 
-    constructor(options: OptionsType) {
+    constructor(options?: OptionsType) {
         if (options && options.ignoreConversionErrors) {
             this.ignoreConversionErrors = options.ignoreConversionErrors;
         }

--- a/src/MapboxStyleParser.ts
+++ b/src/MapboxStyleParser.ts
@@ -31,7 +31,7 @@ type SymbolType = {
 
 type OptionsType = {
     ignoreConversionErrors?: boolean;
-} | undefined;
+};
 
 export class MapboxStyleParser implements StyleParser {
 

--- a/src/Util/MapboxStyleUtil.ts
+++ b/src/Util/MapboxStyleUtil.ts
@@ -89,6 +89,9 @@ class MapboxStyleUtil {
    * @param obj The object to be checked
    */
   public static allUndefined(obj: any): boolean {
+    if (!obj) {
+      return true;
+    }
     const keys = Object.keys(obj);
     return !keys.some((k: string) => {
       return typeof obj[k] !== 'undefined';

--- a/src/Util/MapboxStyleUtil.ts
+++ b/src/Util/MapboxStyleUtil.ts
@@ -19,7 +19,7 @@ class MapboxStyleUtil {
   public static getScaleForResolution(resolution: number): number {
     var dpi = 25.4 / 0.28;
     var mpu = 1;
-    var inchesPerMeter = 39.37;
+    var inchesPerMeter = 39.37008;
 
     return resolution * mpu * inchesPerMeter * dpi;
   }
@@ -55,7 +55,7 @@ class MapboxStyleUtil {
   static getResolutionForScale(scale: number): number {
     let dpi = 25.4 / 0.28;
     let mpu = 1;
-    let inchesPerMeter = 39.37;
+    let inchesPerMeter = 39.37008;
 
     return scale / (mpu * inchesPerMeter * dpi);
   }
@@ -72,12 +72,14 @@ class MapboxStyleUtil {
     } else {
       // interpolate values
       const pre = Math.floor(zoom);
-      const post = Math.ceil(zoom);
       const preVal = resolutions[pre];
-      const postVal = resolutions[post];
-      const range = preVal - postVal;
-      const decimal = zoom % 1;
-      resolution = preVal - (range * decimal);
+      // after carefully rearranging
+      // zoom = i + Math.log(resolutions[i] / resolution) / Math.log(zoomFactor)
+      // with the zoomFactor being 2 I've arrived at this formula to properly
+      // calculate the resolution:
+      resolution = Math.pow(2, pre) * preVal / Math.pow(2, zoom);
+      // this still gives some smallish rounding errors, but at the 8th digit after
+      // the dot this is ok
     }
     return this.getScaleForResolution(resolution);
   }


### PR DESCRIPTION
This adds a flag to ignore conversion errors when converting from/to mapbox. It also fixes reading/writing  to construct/convert from the expected format.

Also fixes zoom to resolution conversion.

@terrestris/devs Please review.