### PR TITLE
[WIP] Parse RasterSymbolizer

### DIFF
--- a/data/mapbox/raster_simpleraster.ts
+++ b/data/mapbox/raster_simpleraster.ts
@@ -1,0 +1,21 @@
+const rasterSimpleRaster: any = {
+  "version": 8,
+  "name": "Simple Raster",
+  "layers": [
+    {
+      "id": "Simple Raster",
+      "type": "raster",
+      "paint": {
+        'raster-opacity': 0.5,
+        'raster-brightness-max': 1,
+        'raster-brightness-min': 0,
+        'raster-saturation': 1,
+        'raster-contrast': 1,
+        'raster-resampling': 'linear',
+        'raster-fade-duration': 200
+      }
+    }
+  ]
+};
+
+export default rasterSimpleRaster;

--- a/data/styles/raster_simpleraster.ts
+++ b/data/styles/raster_simpleraster.ts
@@ -1,0 +1,20 @@
+import { Style } from 'geostyler-style';
+
+const rasterSimpleRaster: Style = {
+  'name': 'Simple Raster',
+  'rules': [{
+    'name': 'Simple Raster',
+    'symbolizers': [{
+      'kind': 'Raster',
+      'opacity': 0.5,
+      'brightnessMax': 1,
+      'brightnessMin': 0,
+      'saturation': 1,
+      'contrast': 1,
+      'resampling': 'linear',
+      'fadeDuration': 200
+    }]
+  }]
+};
+
+export default rasterSimpleRaster;

--- a/src/MapboxStyleParser.spec.ts
+++ b/src/MapboxStyleParser.spec.ts
@@ -31,6 +31,8 @@ import line_patternline from '../data/styles/line_patternline';
 import mb_line_patternline from '../data/mapbox/line_patternline';
 import point_placeholdertext_simple from '../data/styles/point_placeholderText_simple';
 import mb_point_placeholdertext_simple from '../data/mapbox/point_placeholderText_simple';
+import raster_simpleraster from '../data/styles/raster_simpleraster';
+import mb_raster_simpleraster from '../data/mapbox/raster_simpleraster';
 
 it('MapboxStyleParser is defined', () => {
   expect(MapboxStyleParser).toBeDefined();
@@ -165,6 +167,15 @@ describe('MapboxStyleParser implements StyleParser', () => {
         });
     });
 
+    it('can read a mapbox Raster style', () => {
+      expect.assertions(2);
+      return styleParser.readStyle(mb_raster_simpleraster)
+        .then((geoStylerStyle: Style) => {
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(raster_simpleraster);
+        });
+    });
+
     it('can read a mapbox style with multiple layers', () => {
       expect.assertions(2);
       return styleParser.readStyle(mb_multi_simpleline_simplefill)
@@ -254,6 +265,15 @@ describe('MapboxStyleParser implements StyleParser', () => {
         .then((mbStyle: any) => {
           expect(mbStyle).toBeDefined();
           expect(JSON.parse(mbStyle)).toEqual(mb_circle_simplecircle);
+        });
+    });
+
+    it('can write a mapbox Raster style', () => {
+      expect.assertions(2);
+      return styleParser.writeStyle(raster_simpleraster)
+        .then((mbStyle: any) => {
+          expect(mbStyle).toBeDefined();
+          expect(JSON.parse(mbStyle)).toEqual(mb_raster_simpleraster);
         });
     });
 


### PR DESCRIPTION
**Important:** Please wait with merging this PR until [this PR](https://github.com/terrestris/geostyler-style/pull/116) in `geostyler-style` was merged and released.

Initial implementation for parsing RasterSymbolizer. Currently, only handles mapbox specific properties and ignores [SLD related properties](https://github.com/terrestris/geostyler-sld-parser/pull/168).

I.e.
- raster-opacity
- raster-hue-rotate
- raster-brightness-min
- raster-brightness-max
- raster-saturation
- raster-contrast
- raster-resampling
- raster-fade-duration